### PR TITLE
Fixes issue on a fresh clone where the env is not populated

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,1 @@
+API_URL=http://localhost:8000


### PR DESCRIPTION
There is an example env for the NestJS part but not for NextJS that fails on a fresh clone.

In this way the user knows he needs to customize the .env in the frontend 🤝 

<img width="1107" alt="Screenshot 2025-01-25 alle 18 09 02" src="https://github.com/user-attachments/assets/331d612e-56dd-42e2-ac61-561be5c19ab0" />
