### PR TITLE
feat: docker container for postgresql

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -16,6 +16,10 @@ DB_USERNAME=postgres
 DB_PASSWORD=password
 DB_NAME=turborepo
 
+#PGADMIN Configuration
+PGADMIN_DEFAULT_EMAIL=admin@admin.com
+PGADMIN_DEFAULT_PASSWORD=admin
+
 #Mail Configuration
 MAIL_HOST=gmail
 MAIL_USERNAME=

--- a/apps/api/docker-compose.dev.yml
+++ b/apps/api/docker-compose.dev.yml
@@ -1,0 +1,37 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:17.1-alpine
+    container_name: turbo-npn-postgres
+    ports:
+      - "${DB_PORT}:5432"
+    environment:
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - postgres-network
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: turbo-npn-pgadmin
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+      PGADMIN_CONFIG_SERVER_MODE: 'False'
+    ports:
+      - "5050:80"
+    depends_on:
+      - postgres
+    networks:
+      - postgres-network
+
+networks:
+  postgres-network:
+    driver: bridge
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
**feat: Add Docker configuration for PostgreSQL and pgAdmin**

- Set up PostgreSQL 17.1-alpine container with environment variables
- Add pgAdmin 4 container for database management
- Configure network bridge between containers
- Add persistent volume for PostgreSQL data
- Update .env.example with pgAdmin credentials

This setup provides a containerized development environment for the database with a web-based administration interface.