### PR TITLE
fix: add module name mapper to Jest configuration

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,6 +25,9 @@
       "json",
       "ts"
     ],
+    "moduleNameMapper": {
+      "^@/(.*)$": "<rootDir>/$1"
+    },
     "rootDir": "src",
     "testEnvironment": "node",
     "testRegex": ".*\\.spec\\.ts$",


### PR DESCRIPTION
# Fix Jest Module Name Mapping

Added `moduleNameMapper` to Jest configuration to resolve imports starting with `@/` in the test environment.

## Changes Made
- Added `moduleNameMapper` to Jest configuration in `package.json` to properly resolve imports starting with `@/`

## Problem Solved
- Test files were unable to resolve imports like `@/features/...`
- Tests were failing with "Cannot find module '@/features/...' from '...'" errors

This change ensures that import paths in test files will be resolved correctly, allowing tests to run successfully.